### PR TITLE
feat: add experimental test table parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,21 @@ use({
 })
 ```
 
+You can also supply optional arguments to the setup function if you want to
+enable experimental features.
+
+```lua
+require("neotest").setup({
+  adapters = {
+    require("neotest-go")({
+      experimental = { 
+        test_table = true,
+      }
+    })
+  }
+})
+```
+
 ## Usage
 
 _NOTE_: all usages of `require('neotest').run.run` can be mapped to a command in your config (this is not included and should be done by the user)

--- a/lua/neotest-go/init.lua
+++ b/lua/neotest-go/init.lua
@@ -191,21 +191,37 @@ function adapter.discover_positions(path)
   if get_experimental_opts().test_table then
     query = query .. [[
 
-    (short_var_declaration
-      left: (expression_list
-        (identifier) @table.name)
-        (#match? @table.name "test")
-      right: (expression_list
-        (composite_literal
-          (literal_value
-            (literal_element
-              (literal_value
-                (keyed_element
-                  (literal_element
-                    (identifier) @test.field.name
-                    (#match? @test.field.name "name|desc"))
-                  (literal_element
-                    (interpreted_string_literal) @test.name)))) @test.definition ))))
+    (block
+      (short_var_declaration
+        left: (expression_list
+          (identifier) @test.cases)
+        right: (expression_list
+          (composite_literal
+            (literal_value
+              (literal_element
+                (literal_value
+                  (keyed_element
+                    (literal_element
+                      (identifier) @test.field.name)
+                    (literal_element
+                      (interpreted_string_literal) @test.name)))) @test.definition))))
+      (for_statement
+        (range_clause
+          left: (expression_list
+            (identifier) @test.case)
+          right: (identifier) @test.cases1
+            (#eq? @test.cases @test.cases1))
+        body: (block
+          (call_expression
+            function: (selector_expression
+              field: (field_identifier) @test.method)
+              (#match? @test.method "^Run$")
+            arguments: (argument_list
+              (selector_expression
+                operand: (identifier) @test.case1
+                (#eq? @test.case @test.case1)
+                field: (field_identifier) @test.field.name1
+                (#eq? @test.field.name @test.field.name1)))))))
     ]]
   end
 


### PR DESCRIPTION
I added a query for test table simple enough for my common use case. Right now, it only identifies them by:

- matching `test` identifier
- and also the `name|desc` field

![image](https://user-images.githubusercontent.com/18410908/175839211-18617cd7-889f-4b33-9608-1f13080fc822.png)
