### PR TITLE
feat: add args option to setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ use({
 ```
 
 You can also supply optional arguments to the setup function if you want to
-enable experimental features.
+enable experimental features or provide more arguments to `go test` command.
 
 ```lua
 require("neotest").setup({
@@ -37,7 +37,8 @@ require("neotest").setup({
     require("neotest-go")({
       experimental = { 
         test_table = true,
-      }
+      },
+      args = { "-count=1", "-timeout=60s" }
     })
   }
 })

--- a/lua/neotest-go/init.lua
+++ b/lua/neotest-go/init.lua
@@ -88,6 +88,10 @@ local function get_experimental_opts()
   }
 end
 
+local get_args = function()
+  return {}
+end
+
 ---Convert the json output from `gotest` to an intermediate format more similar to
 ---neogit.Result. Collect the progress of each test into a subtable and add a field for
 ---the final result
@@ -273,7 +277,7 @@ function adapter.build_spec(args)
     '-v',
     '-json',
     get_build_tags(),
-    args.extra_args or {},
+    vim.list_extend(get_args(), args.extra_args or {}),
     unpack(cmd_args),
   })
 
@@ -344,6 +348,13 @@ setmetatable(adapter, {
       end
     end
 
+    if is_callable(opts.args) then
+      get_args = opts.args
+    elseif opts.args then
+      get_args = function()
+        return opts.args
+      end
+    end
     return adapter
   end,
 })


### PR DESCRIPTION
Added an optional parameter `args` to the setup function which allows you to add arguments to the `go test` command instead of providing them through `neotest.run.run(extra_args={"-race"})`