### PR TITLE
Adds dap support

### DIFF
--- a/lua/neotest-go/utils.lua
+++ b/lua/neotest-go/utils.lua
@@ -1,0 +1,62 @@
+local M = {}
+
+M.benchmark_regex = '[^Benchmark$|^Benchmark\\P{Ll}.*]'
+
+---@param strategy string
+---@param args table
+---@return table | nil
+M.get_strategy_config = function(strategy, args)
+  local config = {
+    dap = function()
+      return {
+        type = 'go',
+        name = 'Neotest Debugger',
+        request = 'launch',
+        mode = 'test',
+        program = './${relativeFileDirname}',
+        args = args,
+      }
+    end,
+  }
+  if config[strategy] then
+    return config[strategy]()
+  end
+
+  return nil
+end
+
+--@param test_func_name string
+--@return boolean
+M.is_benchmark_test = function(test_func_name)
+  local rg = vim.regex(M.benchmark_regex)
+
+  local match  = rg:match_str(test_func_name)
+  if match == 0 or match == nil then
+    return false
+  end
+  return true
+end
+
+---@param func_name string
+---@return table
+M.get_test_function_debug_args = function(func_name)
+  if M.is_benchmark_test(func_name) then
+    return {
+      '-test.bench',
+      '^' .. func_name .. '$',
+      '-test.run',
+      'a^',
+    }
+  end
+
+  -- TODO: add testify support
+  -- see vscode-go implementation at https://github.com/golang/vscode-go/blob/8dfd39349da7a523b4ed0f781c9d10c753be76bf/src/testUtils.ts#L191-L191
+  local args = {
+    '-test.run',
+    '^' .. func_name .. '$',
+  }
+
+  return args
+end
+
+return M

--- a/tests/unit/utils_spec.lua
+++ b/tests/unit/utils_spec.lua
@@ -1,0 +1,42 @@
+local utils = require('neotest-go.utils')
+
+describe('utils', function()
+  describe('is_benchmark_test', function()
+    it('returns false on test functions', function()
+      is_bench = utils.is_benchmark_test('TestExample')
+      assert.is.False(is_bench)
+    end)
+
+    it('returns true on benchmark functions', function()
+      is_bench = utils.is_benchmark_test('BenchmarkExample')
+      assert.is.True(is_bench)
+    end)
+
+    it('returns false on empty function name', function()
+      is_bench = utils.is_benchmark_test('')
+      assert.is.False(is_bench)
+    end)
+  end)
+
+  describe('get_test_function_debug_args', function()
+    it('with test function', function()
+      local args = utils.get_test_function_debug_args('TestExample')
+
+      assert.are.same(args, {
+        '-test.run',
+        '^TestExample$',
+      })
+    end)
+
+    it('with benchmark function', function()
+      local args = utils.get_test_function_debug_args('BenchmarkExample')
+
+      assert.are.same(args, {
+        '-test.bench',
+        '^BenchmarkExample$',
+        '-test.run',
+        'a^',
+      })
+    end)
+  end)
+end)


### PR DESCRIPTION
This is a starting point to add DAP support.

Current status

- [x] Test* functions
- [ ] Sub test functions with `t.Run`
- [x] Example* functions
- [ ] Benchmark functions (it is not supported by the plugin right now, so DAP will not work)
- [ ] Testify suites

The status sign is broken right now after a debugging session, I haven't look at why right now.