### PR TITLE
feat: search entire go.mod for the module name

### DIFF
--- a/lua/neotest-go/utils.lua
+++ b/lua/neotest-go/utils.lua
@@ -111,9 +111,12 @@ function utils.get_go_module_name(go_root)
     logger.error("neotest-go: couldn't read go.mod file: " .. gomodule)
     return
   end
-  local line = gomodule[1]
-  local module = line:match("module (.+)")
-  return module
+  for _, line in pairs(gomodule) do
+      local module = line:match("module (.+)")
+      if module then
+        return module
+      end
+  end
 end
 
 --- Extracts the file name from a neotest id


### PR DESCRIPTION
module name isn't always the first line in go.mod

for examples:
--------
go 1.18

module github.com/cosmos/ibc-go/v5
--------

old version always get the first line of go.mod -> fail to get the module name -> always return failed for every test case