### PR TITLE
Migrate tests to nio async library

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -2,5 +2,6 @@
     "$schema": "https://raw.githubusercontent.com/sumneko/vscode-lua/master/setting/schema.json",
     "Lua.diagnostics.disable": [
         "missing-parameter"
-    ]
+    ],
+    "workspace.checkThirdParty": false
 }

--- a/lua/spec/neotest-go/init_spec.lua
+++ b/lua/spec/neotest-go/init_spec.lua
@@ -1,6 +1,6 @@
-local async = require("plenary.async.tests")
+local nio = require("nio")
+local async = nio.tests
 local plugin = require("neotest-go")
-local lib = require("neotest.lib")
 local assert = require("luassert")
 local say = require("say")
 


### PR DESCRIPTION
Migrate tests to nio async library [along](https://github.com/nvim-neotest/neotest/pull/228) with upstream `neotest` plugin