### PR TITLE
Adds support for DAP

### DIFF
--- a/lua/neotest-go/init.lua
+++ b/lua/neotest-go/init.lua
@@ -69,7 +69,7 @@ function adapter.discover_positions(path)
 
   if get_experimental_opts().test_table then
     query = query
-      .. [[
+        .. [[
 ;; query for list table tests
     (block
       (short_var_declaration
@@ -104,7 +104,7 @@ function adapter.discover_positions(path)
                 field: (field_identifier) @test.field.name1
                 (#eq? @test.field.name @test.field.name1))))))))
 
-;; query for map table tests 
+;; query for map table tests
 	(block
       (short_var_declaration
         left: (expression_list
@@ -148,6 +148,7 @@ end
 ---@return neotest.RunSpec
 function adapter.build_spec(args)
   local results_path = async.fn.tempname()
+  local strategy = args.strategy
   local position = args.tree:data()
   local dir = position.path
   -- The path for the position is not a directory, ensure the directory variable refers to one
@@ -177,13 +178,19 @@ function adapter.build_spec(args)
     vim.list_extend(get_args(), args.extra_args or {}),
     unpack(cmd_args),
   })
-  return {
-    command = table.concat(command, " "),
+  local return_result = {
+    command = table.concat(command, ' '),
     context = {
       results_path = results_path,
-      file = position.path,
-    },
+      file = position.path
+    }
   }
+
+  if strategy == 'dap' then
+    return_result.strategy = utils.get_dap_config()
+  end
+
+  return return_result
 end
 
 ---@async
@@ -226,7 +233,7 @@ function adapter.prepare_results(tree, lines, go_root, go_module)
     local value = node:data()
     if no_results then
       results[value.id] = {
-        status = test_statuses.fail,
+        status = test_statuses.skip,
         output = empty_result_fname,
       }
       break

--- a/lua/neotest-go/utils.lua
+++ b/lua/neotest-go/utils.lua
@@ -17,6 +17,21 @@ local function get_buf_line(buf, nr)
   return vim.trim(api.nvim_buf_get_lines(buf, nr, nr + 1, false)[1])
 end
 
+function utils.get_function_name(args, position)
+  return utils.get_prefix(args.tree, position.name)
+end
+
+---@return table | nil
+function utils.get_dap_config()
+  return {
+    type = 'go',
+    name = 'Neotest Debugger',
+    request = 'launch',
+    mode = 'test',
+    program = './${relativeFileDirname}',
+  }
+end
+
 -- replace whitespace with underscores and remove surrounding quotes
 function utils.transform_test_name(name)
   return name:gsub("[%s]", "_"):gsub('^"(.*)"$', "%1")


### PR DESCRIPTION
Adds support for DAP (Debug Adapter Protocol) to the neotest-go plugin. Now you can launch the debugger directly from the plugin interface. 