### PR TITLE
feat: use --run flag when executing single test ( run single test instead of all of them )

### DIFF
--- a/lua/neotest-go/init.lua
+++ b/lua/neotest-go/init.lua
@@ -161,6 +161,12 @@ function adapter.build_spec(args)
   if fn.isdirectory(position.path) ~= 1 then
     location = fn.fnamemodify(position.path, ":h")
   end
+
+  local run_flag = {}
+  if position.type == "test" then
+    run_flag = { "--run", "\\^" .. utils.get_prefix(args.tree, position.name) .. "\\$" }
+  end
+
   local command = vim.tbl_flatten({
     "cd",
     location,
@@ -171,8 +177,10 @@ function adapter.build_spec(args)
     "-json",
     utils.get_build_tags(),
     vim.list_extend(get_args(), args.extra_args or {}),
+    run_flag,
     dir,
   })
+
   return {
     command = table.concat(command, " "),
     context = {

--- a/lua/spec/neotest-go/init_spec.lua
+++ b/lua/spec/neotest-go/init_spec.lua
@@ -355,6 +355,20 @@ describe("build_spec", function()
     assert.are.same(expected_command, result.command)
     assert.are.same(path, result.context.file)
   end)
+  async.it("build specification for single test", function()
+    local path = vim.loop.cwd() .. "/neotest_go/main_test.go"
+    local tree = plugin.discover_positions(path):children()[1]
+
+    local args = { tree = tree }
+    local expected_command = "cd "
+      .. vim.loop.cwd()
+      .. "/neotest_go && go test -v -json  -count=1 -timeout=60s --run \\^TestAddOne\\$ ./"
+    local result = plugin.build_spec(args)
+    assert.are.same(expected_command, result.command)
+    assert.are.same(path, result.context.file)
+  end)
+
+-- This test is overwriting plugin global state, keep it at end of the file or face the consequences ¯\_(ツ)_/¯
   async.it("build specification for many_table_test.go recuresive run", function()
     local plugin_with_recursive_run = require("neotest-go")({ recursive_run = true })
     local path = vim.loop.cwd() .. "/neotest_go/many_table_test.go"


### PR DESCRIPTION
Run the go test command with --run flag when executing single test.

Support for neotest `type=test` was removed in https://github.com/nvim-neotest/neotest-go/pull/72

This is unfortunate but i believe in wisdom of the maintainers. Anyway i really need this functionality. Otherwise the plugin is unusable on projects with e2e/integration tests. I can't execute the whole suite each time, that is job for the CI.

---
The solution is untested for all the different nested, map/slice based tests. This works for me right now. This PR is mostly for visibility only. I hope when someone encounter the same roadblock they can use this a inspiration how to solve it. 

Plus multiple people are trying to merge stuff to the same piece of code and i don't want to fight over  it right now. 

Way of avoiding this all together would be providing extension point inside the `build_spec` function for users to change the outcome themselves. Something in line of 

```go
require("neotest-go")({
     test_command_hook = function(command, position) 
         table.insert(command, "--run")
         table.insert(command, position.name)
     end,
      args = { "-count=1", "-timeout=60s" }
    })
```