### PR TITLE
make CC env variable configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ makes heavy use of tabs and newlines in the error messages, which reduces the re
 the generated virtual text otherwise.
 
 You can also supply optional arguments to the setup function if you want to
-enable experimental features or provide more arguments to `go test` command.
+enable experimental features, provide more arguments to `go test` command, or set the `CC` env variable in the test context.
 
 ```lua
 require("neotest").setup({
@@ -51,7 +51,8 @@ require("neotest").setup({
       experimental = {
         test_table = true,
       },
-      args = { "-count=1", "-timeout=60s" }
+      args = { "-count=1", "-timeout=60s" },
+      c_compiler = "clang",
     })
   }
 })

--- a/lua/neotest-go/init.lua
+++ b/lua/neotest-go/init.lua
@@ -21,6 +21,10 @@ local recursive_run = function()
   return false
 end
 
+local c_compiler = function()
+  return "gcc-11"
+end
+
 ---@type neotest.Adapter
 local adapter = { name = "neotest-go" }
 
@@ -166,6 +170,7 @@ function adapter.build_spec(args)
     "cd",
     location,
     "&&",
+    "CC=" .. c_compiler(),
     "go",
     "test",
     "-v",
@@ -294,6 +299,11 @@ setmetatable(adapter, {
     elseif opts.recursive_run then
       recursive_run = function()
         return opts.recursive_run
+      end
+    end
+    if opts.c_compiler then
+      c_compiler = function()
+        return opts.c_compiler
       end
     end
     return adapter

--- a/lua/spec/neotest-go/init_spec.lua
+++ b/lua/spec/neotest-go/init_spec.lua
@@ -39,6 +39,7 @@ plugin({
     test_table = true,
   },
   args = { "-count=1", "-timeout=60s" },
+  c_compiler = "gcc",
 })
 
 describe("is_test_file", function()
@@ -375,7 +376,7 @@ describe("prepare_results", function()
           table.insert(lines, s)
         end
         local processed_results =
-          plugin.prepare_results(positions, lines, tests_folder, "neotest_go")
+            plugin.prepare_results(positions, lines, tests_folder, "neotest_go")
 
         assert.equals(test_result.status, processed_results[test_file].status)
       end)
@@ -390,8 +391,8 @@ describe("build_spec", function()
 
     local args = { tree = tree }
     local expected_command = "cd "
-      .. vim.loop.cwd()
-      .. "/neotest_go && go test -v -json  -count=1 -timeout=60s ./"
+        .. vim.loop.cwd()
+        .. "/neotest_go && CC=gcc go test -v -json  -count=1 -timeout=60s ./"
     local result = plugin.build_spec(args)
     assert.are.same(expected_command, result.command)
     assert.are.same(path, result.context.file)
@@ -403,8 +404,8 @@ describe("build_spec", function()
 
     local args = { tree = tree }
     local expected_command = "cd "
-      .. vim.loop.cwd()
-      .. "/neotest_go && go test -v -json  -count=1 -timeout=60s ./..."
+        .. vim.loop.cwd()
+        .. "/neotest_go && CC=gcc go test -v -json  -count=1 -timeout=60s ./..."
     local result = plugin_with_recursive_run.build_spec(args)
     assert.are.same(expected_command, result.command)
     assert.are.same(path, result.context.file)


### PR DESCRIPTION
This is to address issues I ran into running tests on macOS with `runtime/cgo` dependencies. The default appears to be `gcc-11`, I needed `clang` for my `arm64` architecture.

I made an effort to utilize the [env configuration in the runners pcall](https://github.com/nvim-neotest/neotest/blob/48f8b5fce704594eb0ff94338e080defca14f0dc/lua/neotest/client/strategies/integrated/init.lua#L36), but passing the configured `CC` there does not correctly configure the execution in the `go test` process.
